### PR TITLE
Issue #53: Add docker login instructions to Quickstart local.

### DIFF
--- a/docs/getting-started/quick-start-local.md
+++ b/docs/getting-started/quick-start-local.md
@@ -93,6 +93,8 @@ services:
       - ./formkiq/dynamodb:/data
 ```
 
+Please note: You may need to run "docker login" to login with your Docker credentials beforehand, if you have not done so already.
+
 Launch using:
 ```
 docker-compose -f docker-compose.yml up -d


### PR DESCRIPTION
Added brief instruction to let readers know to login to docker first before launching if they have not done so already